### PR TITLE
Use match-case syntax for decision blocks in APIUtils

### DIFF
--- a/src/ogd/apis/utils/APIResponse.py
+++ b/src/ogd/apis/utils/APIResponse.py
@@ -89,12 +89,13 @@ class APIResponse:
     @staticmethod
     def FromRequestResult(result:RequestResult.RequestResult, req_type:RESTType):
         _status : ResponseStatus
-        if result.Status == RequestResult.ResultStatus.SUCCESS:
-            _status = ResponseStatus.SUCCESS 
-        elif result.Status == RequestResult.ResultStatus.FAILURE:
-            _status = ResponseStatus.ERR_REQ
-        else:
-            _status = ResponseStatus.ERR_SRV
+        match result.Status:
+            case RequestResult.ResultStatus.SUCCESS:
+                _status = ResponseStatus.SUCCESS 
+            case RequestResult.ResultStatus.FAILURE:
+                _status = ResponseStatus.ERR_REQ
+            case _:
+                _status = ResponseStatus.ERR_SRV
         ret_val = APIResponse(req_type=req_type, val=None, msg=result.Message, status=_status)
         return ret_val
     

--- a/src/ogd/apis/utils/APIUtils.py
+++ b/src/ogd/apis/utils/APIUtils.py
@@ -56,20 +56,21 @@ def gen_interface(game_id, core_config:ConfigSchema, logger:Optional[Logger]=Non
 
     if _game_source.Source is not None:
         # set up interface and request
-        if _game_source.Source.Type.upper() == "MYSQL":
-            ret_val = MySQLInterface(game_id, config=_game_source, fail_fast=False)
-            if logger:
-                logger.info(f"Using MySQLInterface for {game_id}")
-        elif _game_source.Source.Type.upper() == "BIGQUERY":
-            if logger:
-                logger.info(f"Generating BigQueryInterface for {game_id}, from directory {os.getcwd()}...")
-            ret_val = BigQueryInterface(game_id=game_id, config=_game_source, fail_fast=False)
-            if logger:
-                logger.info("Done")
-        else:
-            ret_val = MySQLInterface(game_id, config=_game_source, fail_fast=False)
-            if logger:
-                logger.warning(f"Could not find a valid interface for {game_id}, defaulting to MySQL!")
+        match _game_source.Source.Type.upper():
+            case "MYSQL":
+                ret_val = MySQLInterface(game_id, config=_game_source, fail_fast=False)
+                if logger:
+                    logger.info(f"Using MySQLInterface for {game_id}")
+            case "BIGQUERY":
+                if logger:
+                    logger.info(f"Generating BigQueryInterface for {game_id}, from directory {os.getcwd()}...")
+                ret_val = BigQueryInterface(game_id=game_id, config=_game_source, fail_fast=False)
+                if logger:
+                    logger.info("Done")
+            case _:
+                ret_val = MySQLInterface(game_id, config=_game_source, fail_fast=False)
+                if logger:
+                    logger.warning(f"Could not find a valid interface for {game_id}, defaulting to MySQL!")
     return ret_val
 
 # def gen_coding_interface(game_id) -> Optional[CodingInterface]:


### PR DESCRIPTION
Switches some blocks to match-case syntax.
In particular:

* `FromRequestResult` in `APIResponse` class
* `gen_interface` in `APIUtils` utility file

Resolves #17.